### PR TITLE
Remove [testenv:venv] now that `tox --devenv` is a thing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-project = dumbconf
 # These should match the travis env list
 envlist = py27,py35,py36,pypy
 
@@ -11,10 +10,6 @@ commands =
     coverage report --fail-under 100
     pre-commit install -f --install-hooks
     pre-commit run --all-files
-
-[testenv:venv]
-envdir = venv-{[tox]project}
-commands =
 
 [pep8]
 ignore = E265,E501,W504


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos